### PR TITLE
Update from ServiceNow !ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ seviceN.
 stwinkle.
 TheTreyKyle.
 ttoter.
+ynr-ram.
 zaidongy.
 kcimpulse.
 158w5a0532.
@@ -263,5 +264,4 @@ Watermark-ServiceNow.
 wcarroll.
 wkbroxton.
 xdisplay.
-ynr-ram.
 youthinkasido.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ aatrey882.
 ashleysnyder.
 b1naryst0rm.
 bradtiltonnow.
+brichards99.
 
 Other contributors:
-brichards99.
 Decoder-Paul.
 dhruvii-powershell.
 igrzhukovich.
@@ -263,4 +263,5 @@ Watermark-ServiceNow.
 wcarroll.
 wkbroxton.
 xdisplay.
+ynr-ram.
 youthinkasido.


### PR DESCRIPTION
[getTabNameandFieldName.txt](https://github.com/ynr-ram/code-snippets-getTableandFieldNames/files/9690932/getTabNameandFieldName.txt)

By using this code we can get all the table names and field label name and backend name